### PR TITLE
Implement packet split for realtime udp frames

### DIFF
--- a/dist/lib/light.js
+++ b/dist/lib/light.js
@@ -516,12 +516,12 @@ export class Light {
                 throw new Error("UDP not supported in browser");
             // Generate the header
             let tokenArray = this.token.getTokenDecoded();
-            let udpHeader = Buffer.alloc(tokenArray.length + 4);
             let rawFrame = frame.toOctet();
             let packetId = 0;
             do {
                 let framePart = rawFrame.slice(0, 900);
                 rawFrame = rawFrame.slice(900);
+                let udpHeader = Buffer.alloc(tokenArray.length + 4);
                 udpHeader.writeUInt8(0x03); // the version number
                 udpHeader.fill(tokenArray, 1); // the actual token, 8 bytes
                 udpHeader.writeUInt8(0x00, tokenArray.length + 1); // zero blanking

--- a/dist/lib/light.js
+++ b/dist/lib/light.js
@@ -517,20 +517,27 @@ export class Light {
             // Generate the header
             let tokenArray = this.token.getTokenDecoded();
             let udpHeader = Buffer.alloc(tokenArray.length + 4);
-            udpHeader.writeUInt8(0x03); // the version number
-            udpHeader.fill(tokenArray, 1); // the actual token, 8 bytes
-            udpHeader.writeUInt8(0x00, tokenArray.length + 1); // zero blanking
-            udpHeader.writeUInt8(0x00, tokenArray.length + 2); // zero blanking
-            udpHeader.writeUInt8(0x00, tokenArray.length + 3); // number of packets (currently only 1 as i only hav 250 leds)
-            // Generate the body
-            const data = Buffer.alloc(udpHeader.length + frame.getNLeds() * 3);
-            data.fill(udpHeader);
-            data.fill(frame.toOctet(), udpHeader.length);
-            this.udpClient.send(data, 7777, this.ipaddr, (error) => {
-                if (error) {
-                    console.warn(error);
-                }
-            });
+            let rawFrame = frame.toOctet();
+            let packetId = 0;
+            do {
+                let framePart = rawFrame.slice(0, 900);
+                rawFrame = rawFrame.slice(900);
+                udpHeader.writeUInt8(0x03); // the version number
+                udpHeader.fill(tokenArray, 1); // the actual token, 8 bytes
+                udpHeader.writeUInt8(0x00, tokenArray.length + 1); // zero blanking
+                udpHeader.writeUInt8(0x00, tokenArray.length + 2); // zero blanking
+                udpHeader.writeUInt8(packetId, tokenArray.length + 3);
+                // Generate the body
+                const data = Buffer.alloc(udpHeader.length + framePart.length);
+                data.fill(udpHeader);
+                data.fill(framePart, udpHeader.length);
+                this.udpClient.send(data, 7777, this.ipaddr, (error) => {
+                    if (error) {
+                        console.warn(error);
+                    }
+                });
+                packetId++;
+            } while (rawFrame.length > 0);
         });
     }
     /**

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -503,7 +503,6 @@ export class Light {
 
     // Generate the header
     let tokenArray = this.token.getTokenDecoded();
-    let udpHeader = Buffer.alloc(tokenArray.length + 4);
 
     let rawFrame = frame.toOctet();
     let packetId = 0;
@@ -511,6 +510,7 @@ export class Light {
       let framePart = rawFrame.slice(0, 900);
       rawFrame = rawFrame.slice(900);
 
+      let udpHeader = Buffer.alloc(tokenArray.length + 4);
       udpHeader.writeUInt8(0x03); // the version number
       udpHeader.fill(tokenArray, 1); // the actual token, 8 bytes
       udpHeader.writeUInt8(0x00, tokenArray.length + 1); // zero blanking


### PR DESCRIPTION
The current implementation of `sendRealTimeFrameUDP()` is only usable for devices with up to 300 LEDs because for more LEDs multiple packets have to be sent. I've implemented splitting the frames in multiple packets according to https://xled-docs.readthedocs.io/en/latest/protocol_details.html#version-3 and it works for me with 400 LEDs. 